### PR TITLE
feature/#100/인증 게시글 파일 크기 제한 변경

### DIFF
--- a/project_frontend/src/pages/patchCertification.js
+++ b/project_frontend/src/pages/patchCertification.js
@@ -68,7 +68,7 @@ function PatchCertification() {
 			}
 			if (!fileSizeValid(imageFile.size)) {
 				e.target.value = '';
-				alert('업로드 가능한 최대 파일 크기는 파일 당 5MB입니다.');
+				alert('업로드 가능한 최대 파일 크기는 파일 당 10MB입니다.');
 				return;
 			}
 			createImageURL(imageFile); // 썸네일용 이미지 url 생성

--- a/project_frontend/src/pages/postCertification.js
+++ b/project_frontend/src/pages/postCertification.js
@@ -62,7 +62,7 @@ function PostCertification() {
 			}
 			if (!fileSizeValid(imageFile.size)) {
 				e.target.value = '';
-				alert('업로드 가능한 최대 파일 크기는 파일 당 5MB입니다.');
+				alert('업로드 가능한 최대 파일 크기는 파일 당 10MB입니다.');
 				return;
 			}
 			createImageURL(imageFile); // 썸네일용 이미지 url 생성

--- a/project_frontend/src/utils/fileUploadValidHandler.js
+++ b/project_frontend/src/utils/fileUploadValidHandler.js
@@ -1,5 +1,5 @@
 const ALLOW_FILE_EXTENSION = 'jpg,jpeg,png,gif,mp4';
-const FILE_SIZE_MAX_LIMIT = 5 * 1024 * 1024;
+const FILE_SIZE_MAX_LIMIT = 10 * 1024 * 1024;
 
 const fileExtensionValid = (originalFileName) => {
 	const extension = removeFileName(originalFileName);


### PR DESCRIPTION
# 인증 게시글 파일 크기 제한 변경

### 이슈 번호 : #100 

## 변경 사항
- 인증 게시글 파일당 크기 제한 10MB로 변경

## 그 외
- 

## 질문 사항
- 