### PR TITLE
feature/#110/인증 게시글 카드 CSS 수정

### DIFF
--- a/project_frontend/src/components/main/certificationCard.js
+++ b/project_frontend/src/components/main/certificationCard.js
@@ -37,8 +37,8 @@ const CertificationItemCard = styled.div`
 		overflow: hidden;
 		-webkit-box-orient: vertical;
 		font-size: 2.5rem;
-		line-height: 2.5rem;
-		height: 3rem;
+		line-height: 3.5rem;
+		height: 3.5rem;
 		-webkit-line-clamp: 1;
 		text-overflow: ellipsis;
 		margin-bottom: 2rem;


### PR DESCRIPTION
# 인증 게시글 카드 CSS 수정

### 이슈 번호 : #110 

## 변경 사항
- 인증 게시글 카드 제목 위아래 잘림 해결

## 그 외
- 

## 질문 사항
- 