### PR TITLE
feature/#163/모집 게시글 마감 시 뒤로가기 구현

### DIFF
--- a/project_frontend/src/apis/boards/recruitment.js
+++ b/project_frontend/src/apis/boards/recruitment.js
@@ -74,7 +74,7 @@ const EditRecruitment = (boardId, form, navigate, setIsLoading) => {
 	}
 };
 
-const closeRecruitment = (boardId, getNewDetails) => {
+const closeRecruitment = (boardId, getClosedDetails) => {
 	if (
 		window.confirm(
 			'모집을 마감하시겠습니까? 이는 되돌릴 수 없으며, 이후 게시글을 수정할 수 없습니다.'
@@ -87,7 +87,7 @@ const closeRecruitment = (boardId, getNewDetails) => {
 			.then((res) => {
 				alert('마감 처리가 완료되었습니다.');
 				// console.log(res.data.boardId);
-				getNewDetails();
+				getClosedDetails();
 			})
 			.catch((error) => {
 				console.log(error);

--- a/project_frontend/src/apis/boards/recruitment.js
+++ b/project_frontend/src/apis/boards/recruitment.js
@@ -14,7 +14,6 @@ const getRecruitment = (boardId, getBoardDetails, navigate) => {
 };
 
 const writeRecruitment = (form, navigate, setIsLoading) => {
-	console.log(form);
 	if (
 		form.activityCategory === '' ||
 		form.title === '' ||
@@ -29,7 +28,6 @@ const writeRecruitment = (form, navigate, setIsLoading) => {
 		return;
 	}
 	setIsLoading(true);
-	console.log('writeRecruitment 실행');
 	axios
 		.post(`/api/boards/recruitment`, form)
 		.then((res) => {
@@ -59,7 +57,6 @@ const EditRecruitment = (boardId, form, navigate, setIsLoading) => {
 	}
 	if (window.confirm('게시글 수정을 완료하시겠습니까?')) {
 		setIsLoading(true);
-		console.log('EditRecruitment 실행');
 		axios
 			.patch(`/api/boards/recruitment/${boardId}`, form)
 			.then((res) => {
@@ -81,18 +78,16 @@ const closeRecruitment = (boardId, getClosedDetails) => {
 		)
 	) {
 		// 모달창으로 수정할 것
-		console.log(`모집 게시글 마감`);
 		axios
 			.patch(`/api/boards/recruitment/${boardId}/recruitment-status`)
 			.then((res) => {
-				alert('마감 처리가 완료되었습니다.');
 				// console.log(res.data.boardId);
 				getClosedDetails();
 			})
 			.catch((error) => {
 				console.log(error);
 				// console.log(error.status);
-				console.log('마감 처리 실패');
+				alert('마감 처리에 실패했습니다.');
 			});
 	}
 };
@@ -100,7 +95,6 @@ const closeRecruitment = (boardId, getClosedDetails) => {
 const deleteRecruitment = (boardId, navigate) => {
 	if (window.confirm('게시글을 삭제하시겠습니까?')) {
 		// 모달창으로 수정할 것
-		console.log(`모집 게시글 삭제`);
 		axios
 			.delete(`/api/boards/recruitment/${boardId}`)
 			.then((res) => {
@@ -111,7 +105,7 @@ const deleteRecruitment = (boardId, navigate) => {
 			.catch((error) => {
 				console.log(error);
 				// console.log(error.status);
-				console.log('게시글 삭제 실패');
+				alert('게시글 삭제에 실패했습니다.');
 			});
 	}
 };

--- a/project_frontend/src/components/boardDetails/boardContent.js
+++ b/project_frontend/src/components/boardDetails/boardContent.js
@@ -34,8 +34,16 @@ const BoardContent = () => {
 	};
 	useEffect(() => {
 		getRecruitment(params.boardId, getBoardDetails, navigate);
-		if (!isOnRecruitment) navigate(-1);
 	}, [isOnRecruitment]);
+	useEffect(() => {
+		if (!isOnRecruitment) {
+			const navigateBack = setTimeout(() => {
+				alert('마감 처리가 완료되었습니다.');
+				navigate(-1);
+			}, 50);
+			return () => clearTimeout(navigateBack);
+		}
+	}, [boardDetails]);
 
 	let items = ['활동 지역', '모집 구분', '시작 예정', '모집 상태'];
 	let values = [

--- a/project_frontend/src/components/boardDetails/boardContent.js
+++ b/project_frontend/src/components/boardDetails/boardContent.js
@@ -29,11 +29,12 @@ const BoardContent = () => {
 		setBoardDetails(value);
 	};
 	const [isOnRecruitment, setIsOnRecruitment] = useState(1);
-	const getNewDetails = () => {
+	const getClosedDetails = () => {
 		setIsOnRecruitment(0);
 	};
 	useEffect(() => {
 		getRecruitment(params.boardId, getBoardDetails, navigate);
+		if (!isOnRecruitment) navigate(-1);
 	}, [isOnRecruitment]);
 
 	let items = ['활동 지역', '모집 구분', '시작 예정', '모집 상태'];
@@ -88,7 +89,7 @@ const BoardContent = () => {
 													onClick={() => {
 														closeRecruitment(
 															boardDetails.boardId,
-															getNewDetails
+															getClosedDetails
 														);
 													}}>
 													마감


### PR DESCRIPTION
# 모집 게시글 마감 시 뒤로가기 구현

### 이슈 번호 : #163 

## 변경 사항
- getNewDetails -> getClosedDetails로 rename, 초기 조회가 아니고 getClosedDetails가 실행되었다면 useEffect 내에서 navigate(-1)

## 그 외
- 

## 질문 사항
- 