### PR TITLE
feature/#168/모집 게시글 카드 CSS 수정

### DIFF
--- a/project_frontend/src/components/main/card.js
+++ b/project_frontend/src/components/main/card.js
@@ -18,30 +18,31 @@ const Card = ({ content }) => {
 			onClick={() =>
 				movePath(navigate, `/boards/recruitment/${content.boardId}`)
 			}>
-			<div className="closed" />
-			<div className="category">
+			<div className='closed' />
+			<div className='category'>
 				시작 예정일
-				<VerticalBar className="bar" />
+				<VerticalBar className='bar' />
 				{content.startingDate}
-				<VerticalBar className="bar" />
+				<VerticalBar className='bar' />
 				{content.activityCategory}
 			</div>
-			<div className="title">{content.title}</div>
-			<div className="contentBody">{newContent}</div>
-			<div className="writerProfileWrap">
+			<div className='title'>{content.title}</div>
+			<div className='contentBody'>{newContent}</div>
+			<div style={{ flexGrow: 1 }} />
+			<div className='writerProfileWrap'>
 				{content.region}
 				<hr />
 				<div style={{ display: 'flex', justifyContent: 'space-between' }}>
-					<div className="writerProfile">
+					<div className='writerProfile'>
 						<GlobalProfile
-							size="4.6rem"
-							margin="1rem 1.5rem 1rem 0"
+							size='4.6rem'
+							margin='1rem 1.5rem 1rem 0'
 							src={content.writerProfileUrl}></GlobalProfile>
 						{content.writerAlias}({content.firstFourLettersOfEmail}
 						****)
 					</div>
-					<div className="numofComments">
-						<Message size="2.5rem"></Message>
+					<div className='numofComments'>
+						<Message size='2.5rem'></Message>
 						<span>{content.countOfCommentAndReplyComment}</span>
 					</div>
 				</div>

--- a/project_frontend/src/components/main/mainStyledComponents.js
+++ b/project_frontend/src/components/main/mainStyledComponents.js
@@ -41,9 +41,10 @@ const BoardItemsWrap = styled.div`
 const BoardItemCard = styled.div`
 	// 부모 컴포넌트인 BoardItemsWrap에서 너비를 지정해주었으므로 자식 컴포넌트(아이템)의 너비는 지정하지 말아야 함
 	height: 40rem;
-
+	display: flex;
+	flex-direction: column;
 	border-radius: 0.7rem;
-	padding: 4rem 3rem 2rem 3rem;
+	padding: 4rem 3rem 1rem;
 	box-sizing: border-box;
 	background-color: rgba(255, 255, 255, 0.8);
 	border: 0.2rem solid #b3b3b3;
@@ -98,11 +99,9 @@ const BoardItemCard = styled.div`
 		.bar {
 			height: 1.4rem;
 		}
-		@media (max-width: 355px) {
-			font-size: 1.3rem;
-		}
 	}
 	.title {
+		width: 100%;
 		font-size: 2rem;
 		height: 5rem;
 		line-height: 2.5rem;
@@ -127,7 +126,6 @@ const BoardItemCard = styled.div`
 		-webkit-line-clamp: 5;
 	}
 	.writerProfileWrap {
-		margin-top: 3rem;
 		font-size: 1.7rem;
 		text-align: right;
 		color: rgba(40, 40, 40, 0.8);
@@ -157,22 +155,19 @@ const BoardItemCard = styled.div`
 
 	@media (max-width: 425px) {
 		.category {
-			font-size: 1.8rem;
+			font-size: 1.5rem;
 		}
 		.title {
-			font-size: 2.5rem;
+			font-size: 2.3rem;
 			height: 3rem;
 			line-height: 3rem;
 			-webkit-line-clamp: 1;
 		}
 		.contentBody {
-			font-size: 2rem;
+			font-size: 1.8rem;
 			line-height: 2.7rem;
 			height: 10.8rem;
 			-webkit-line-clamp: 4;
-		}
-		.writerProfileWrap {
-			margin-top: 4rem;
 		}
 	}
 `;


### PR DESCRIPTION
# 모집 게시글 카드 CSS 수정

### 이슈 번호 : #168 

## 변경 사항
- 모집 게시글 카드 CSS 내부 요소 여백 및 정렬 속성 수정
- 게시글 카드 본문과 프로필 사이 여백 flex-grow:1의 div로 채우기
- 카드 컴포넌트 display:flex, flex-direction:column으로 내부 정렬
- title width:100%

## 그 외
- 

## 질문 사항
- 