### PR TITLE
feature/#176/로그인 페이지 기본 뒤로가기 이벤트 막기

### DIFF
--- a/project_frontend/package-lock.json
+++ b/project_frontend/package-lock.json
@@ -12,6 +12,7 @@
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
         "axios": "^1.3.2",
+        "history": "^5.3.0",
         "iconsax-react": "^0.0.8",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -9066,6 +9067,14 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
+      }
+    },
+    "node_modules/history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.7.6"
       }
     },
     "node_modules/hoist-non-react-statics": {
@@ -24976,6 +24985,14 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
+    },
+    "history": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/history/-/history-5.3.0.tgz",
+      "integrity": "sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==",
+      "requires": {
+        "@babel/runtime": "^7.7.6"
+      }
     },
     "hoist-non-react-statics": {
       "version": "3.3.2",

--- a/project_frontend/package.json
+++ b/project_frontend/package.json
@@ -8,6 +8,7 @@
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
     "axios": "^1.3.2",
+    "history": "^5.3.0",
     "iconsax-react": "^0.0.8",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/project_frontend/src/components/login/loginStyledComponents.js
+++ b/project_frontend/src/components/login/loginStyledComponents.js
@@ -29,18 +29,10 @@ const WelcomeComment = styled.p`
 const LoginPageWrap = styled.div`
 	height: 90vh;
 	display: flex;
+	flex-direction: column;
 	align-items: center;
 	justify-content: center;
-	flex-direction: column;
-
-	.loginComponentsWrap {
-		text-align: center;
-		user-select: none;
-		display: flex;
-		flex-direction: column;
-		align-items: center;
-		justify-contents: center;
-	}
+	text-align: center;
 `;
 const LoginComments = styled.div`
 	font-family: NanumSquare;

--- a/project_frontend/src/components/login/loginStyledComponents.js
+++ b/project_frontend/src/components/login/loginStyledComponents.js
@@ -27,13 +27,20 @@ const WelcomeComment = styled.p`
 	text-shadow: 0px 3px 3px rgba(0, 0, 0, 0.25);
 `;
 const LoginPageWrap = styled.div`
-	text-align: center;
-	padding-top: 20rem;
-	user-select: none;
+	height: 90vh;
 	display: flex;
-	flex-direction: column;
 	align-items: center;
-	justify-contents: center;
+	justify-content: center;
+	flex-direction: column;
+
+	.loginComponentsWrap {
+		text-align: center;
+		user-select: none;
+		display: flex;
+		flex-direction: column;
+		align-items: center;
+		justify-contents: center;
+	}
 `;
 const LoginComments = styled.div`
 	font-family: NanumSquare;

--- a/project_frontend/src/pages/login.js
+++ b/project_frontend/src/pages/login.js
@@ -1,6 +1,6 @@
-import React from 'react';
-import { Link } from 'react-router-dom';
-import styled from 'styled-components';
+import React, { useEffect } from 'react';
+import { useLocation, useNavigate, Navigate } from 'react-router-dom';
+import { createBrowserHistory } from 'history';
 import {
 	JoinComment,
 	KakaoLoginButton,
@@ -17,25 +17,34 @@ const REDIRECT_URI = `https://${Host}/api/auth/join`;
 const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
 
 function Login() {
+	const { state } = useLocation();
+	const navigate = useNavigate();
+	const history = createBrowserHistory();
+	const preventGoback = () => {
+		history.push(window.location.href);
+		navigate('/');
+		console.log('preventGoback!');
+	};
+	useEffect(() => {
+		history.push(window.location.href);
+		window.addEventListener('popstate', preventGoback);
+		return () => {
+			window.removeEventListener('popstate', preventGoback);
+		};
+	}, []);
 	return (
-		<div>
-			<div>
-				<Link to="/">
-					<CloseButton>
-						<TfiClose
-							size="3rem"
-							color="#3A3A3A"></TfiClose>
-					</CloseButton>
-				</Link>
-			</div>
-			<LoginPageWrap>
+		<LoginPageWrap>
+			<CloseButton onClick={preventGoback} style={{ cursor: 'pointer' }}>
+				<TfiClose size='3rem' color='#3A3A3A'></TfiClose>
+			</CloseButton>
+			<div className='loginComponentsWrap'>
 				<JoinComment />
 				<LoginComments>소셜 계정으로 로그인하기</LoginComments>
 				<a href={KAKAO_AUTH_URL}>
 					<KakaoLoginButton />
 				</a>
-			</LoginPageWrap>
-		</div>
+			</div>
+		</LoginPageWrap>
 	);
 }
 export default Login;

--- a/project_frontend/src/pages/login.js
+++ b/project_frontend/src/pages/login.js
@@ -23,7 +23,6 @@ function Login() {
 	const preventGoback = () => {
 		history.push(window.location.href);
 		navigate('/');
-		console.log('preventGoback!');
 	};
 	useEffect(() => {
 		history.push(window.location.href);


### PR DESCRIPTION
# 로그인 페이지 기본 뒤로가기 이벤트 막기

### 이슈 번호 : #176 

## 변경 사항
- history 패키지 설치 후 뒤로가기 이벤트를 감지
- history.push로 현재 페이지 주소 history 스택에 쌓아 뒤로가기 막은 뒤 임의로 주소 이동

## 그 외
- 

## 질문 사항
- 